### PR TITLE
Follow redirects in Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ USER root
 RUN yum install -y curl
 
 # Download crowd plugin
-RUN curl https://github.com/pingunaut/nexus3-crowd-plugin/releases/download/nexus3-crowd-plugin-3.5.0/nexus3-crowd-plugin-3.5.0.jar --output /opt/sonatype/nexus/system/nexus3-crowd-plugin.jar
+RUN curl -L https://github.com/pingunaut/nexus3-crowd-plugin/releases/download/nexus3-crowd-plugin-3.5.0/nexus3-crowd-plugin-3.5.0.jar --output /opt/sonatype/nexus/system/nexus3-crowd-plugin.jar
 
 # Install plugin
 RUN echo "reference\:file\:nexus3-crowd-plugin.jar = 200" >> /opt/sonatype/nexus/etc/karaf/startup.properties


### PR DESCRIPTION
Without following redirects, I was getting the html contents of a redirect page in the jar file, which results in the following getting an error on startup:

```bash
Error installing bundle listed in startup.properties with url: reference:file:nexus3-crowd-plugin.jar and startlevel: 200
java.lang.NullPointerException
	at org.apache.karaf.main.Main.destroy(Main.java:634)
	at org.sonatype.nexus.karaf.NexusMain.main(NexusMain.java:56)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at com.exe4j.runtime.LauncherEngine.launch(LauncherEngine.java:62)
	at com.install4j.runtime.launcher.UnixLauncher.main(UnixLauncher.java:63)
```

